### PR TITLE
Not working on iPad

### DIFF
--- a/Resources/socket.io-titanium.js
+++ b/Resources/socket.io-titanium.js
@@ -1,6 +1,6 @@
 var platform = {
   isAndroid: /android/i.test(Titanium.Platform.osname),
-  isIPhone: /iphone/i.test(Titanium.Platform.osname),
+  isIPhone: /iphone|ipad/i.test(Titanium.Platform.osname),
   os: function(obj){
     if(platform.isIPhone){
       return obj.iphone();


### PR DESCRIPTION
Added fix for iPad in regex pattern to make "require" work on iPad and Iphone equally.
